### PR TITLE
Support Debian and initial user creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ script:
   # Start the service
   - ansible-container run -d
   - docker ps -a
-  - docker logs tests_rabbitmq-container_1
 
   # Run CentOS tests
   - ansible-playbook test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,36 @@ script:
   - ansible-container build
 
   # Install the role into the project
-  - echo "Installing and testing git+https://github.com/${TRAVIS_REPO_SLUG},${TRAVIS_COMMIT}"
-  - ansible-container install git+https://github.com/${TRAVIS_REPO_SLUG},${TRAVIS_COMMIT}
+  
+  - echo "Installing and testing git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-TRAVIS_COMMIT}"
+  - ansible-container install git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-TRAVIS_COMMIT}
 
   # Build the service image
-  - ansible-container build --no-cache
+  - ansible-container build --no-container-cache
 
   # Start the service
   - ansible-container run -d
-  - docker ps
+  - docker ps -a
+  - docker logs tests_rabbitmq-container_1
 
-  # Run tests
+  # Run CentOS tests
+  - ansible-playbook test.yml
+
+  # Stop CentOS environment
+  - ansible-container stop
+  - rm container.yml
+
+  # Copy in Debian container.yml
+  - cp debian-container.yml container.yml
+
+  # Build Debian container
+  - ansible-container build --no-cache
+
+  # Run debian container
+  - ansible-container run -d
+  - docker ps -a
+
+  # Test debian container
   - ansible-playbook test.yml
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ services:
 before_install:
   - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
   - sudo apt-get update -qq
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine
+  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-ce
 
 install:
   # Install the latest Ansible Container and Ansible
-  - pip install git+https://github.com/ansible/ansible-container.git
+  - pip install ansible-container[docker]
   - pip install ansible
 
 
@@ -27,12 +27,15 @@ script:
   - cd tests
   - ansible-container init
 
+  # Run initial build to populate conductor
+  - ansible-container build
+
   # Install the role into the project
   - echo "Installing and testing git+https://github.com/${TRAVIS_REPO_SLUG},${TRAVIS_COMMIT}"
   - ansible-container install git+https://github.com/${TRAVIS_REPO_SLUG},${TRAVIS_COMMIT}
 
   # Build the service image
-  - ansible-container build
+  - ansible-container build --no-cache
 
   # Start the service
   - ansible-container run -d

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ RabbitMQ
 
 Use this role to add a rabbitmq service to your Ansbile container project.
 
-
 Role Variables
 --------------
 
 Set the following environment variables in container.yml:
 
 RABBITMQ_DEFAULT_USER
-> RabbitMQ user name. Defaults to `rabbimq`.
+> RabbitMQ user name. Defaults to `rabbitmq`.
+
+RABBITMQ_DEFAULT_PASSWORD
+> RabbitMQ user password. Defaults to `rabbitmq`.
 
 RABBITMQ_GROUP
 > RabbitMQ user group. Defaults to `rabbitmq`.
@@ -22,9 +24,13 @@ RABBITMQ_DEFAULT_VHOST
 RABBITMQ_NODE_PORT
 > RabbitMQ service port number. Defautls to `5672`
 
-The following variables are set in defaults/main.yml and can be overriden at execution time:
+RABBITMQ_ADMIN_USER
+> RabbitMQ administrator user name. Defaults to `admin`.
 
-The same variables are also available in defaults for standalone container execution.
+RABBITMQ_ADMIN_PASSWORD
+> RabbitMQ administrator password. Defaults to `ChangeMe!`.
+
+Equivalent variables are set in defaults/main.yml and can be overriden at execution time.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 # defaults file for rabbitmq-container1
-username: rabbitmq
-user_group: rabbitmq
-vhost: my_vhost
-port: 5672
+
+port: "{{ RABBITMQ_NODE_PORT | default(5672) }}"
+
+rabbitmq_admin_user: "{{ RABBITMQ_ADMIN_USER | default('admin') }}"
+rabbitmq_admin_password: "{{ RABBITMQ_ADMIN_PASSWORD | default('ChangeMe!') }}"
+
+rabbitmq_application_vhost: "{{ RABBITMQ_DEFAULT_VHOST | default('my_vhost') }}"
+rabbitmq_application_user: "{{ RABBITMQ_DEFAULT_USER | default('rabbitmq') }}"
+rabbitmq_application_password: "{{ RABBITMQ_DEFAULT_PASSWORD | default('rabbitmq') }}"

--- a/meta/container.yml
+++ b/meta/container.yml
@@ -6,4 +6,5 @@ environment:
   RABBITMQ_GROUP: rabbitmq
   RABBITMQ_DEFAULT_VHOST: my_vhost
   RABBITMQ_NODE_PORT: "5672"
-command: ['/usr/bin/dumb-init','rabbitmq']
+entrypoint: ['/usr/local/bin/runrabbit']
+command: []

--- a/meta/container.yml
+++ b/meta/container.yml
@@ -1,10 +1,9 @@
-rabbitmq:
-  image: centos:7
-  ports:
-    - 5672:5672
-  environment:
-    RABBITMQ_DEFAULT_USER: rabbitmq
-    RABBITMQ_GROUP: rabbitmq
-    RABBITMQ_DEFAULT_VHOST: my_vhost
-    RABBITMQ_NODE_PORT: 5672
-  command: ['/usr/bin/dumb-init','rabbitmq']
+from: centos:7
+ports:
+  - 5672:5672
+environment:
+  RABBITMQ_DEFAULT_USER: rabbitmq
+  RABBITMQ_GROUP: rabbitmq
+  RABBITMQ_DEFAULT_VHOST: my_vhost
+  RABBITMQ_NODE_PORT: "5672"
+command: ['/usr/bin/dumb-init','rabbitmq']

--- a/meta/container.yml
+++ b/meta/container.yml
@@ -7,4 +7,4 @@ rabbitmq:
     RABBITMQ_GROUP: rabbitmq
     RABBITMQ_DEFAULT_VHOST: my_vhost
     RABBITMQ_NODE_PORT: 5672
-  command: ['/usr/bin/dumb-init','rabbitmq-server']
+  command: ['/usr/bin/dumb-init','rabbitmq']

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,13 @@ galaxy_info:
   - name: EL
     versions:
     - 7
+  - name: Debian
+    versions:
+    - jessie
+  - name: Ubuntu
+    versions:
+    - 14.04
+    - trusty
 
   galaxy_tags:
     - container

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Install dumb init
   get_url:
     dest: /usr/bin/dumb-init
@@ -6,11 +7,6 @@
     mode: 0775
     validate_certs: no
 
-- name: Install EPEL
-  yum: name=epel-release state=latest update_cache=yes
-
-- name: Install Erlang
-  yum: name=erlang update_cache=yes
-
-- name: install rabbitmq-server
-  yum: name=rabbitmq-server update_cache=yes
+- name: Enable the RabbitMQ Management Console
+  rabbitmq_plugin: names=rabbitmq_management state=enabled
+  when: enable_mgmt_plugin is defined and enable_mgmt_plugin

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Add the RabbitMQ public GPG key to the apt repo
+  apt_key: url=http://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+           state=present
+
+- name: Add RabbitMQ to the sources list
+  apt_repository: 
+    repo: 'deb http://www.rabbitmq.com/debian/ testing main'
+    update_cache: yes
+    state: present
+
+- name: Install RabbitMQ server
+  apt: 
+    name: rabbitmq-server
+    update_cache: yes
+    force: yes 
+    state: installed
+
+- name: Clean apt cache
+  command: apt-get clean
+  when: ansible_os_family == 'Debian'

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Install EPEL
+  yum: name=epel-release state=latest update_cache=yes
+
+- name: Install Erlang
+  yum: name=erlang update_cache=yes
+
+- name: install rabbitmq-server
+  yum: name=rabbitmq-server update_cache=yes
+
+- name: Clean yum cache
+  command: yum clean all
+  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 - include_tasks: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: common.yml
+- include_tasks: common.yml
 
 - name: Template out init script into /usr/bin
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+
+- include_vars: "/src/{{ item }}"
+  with_items: "{{ vars_files }}"
+  when: vars_files is defined and vars_files
+
+- include_tasks: install-debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include_tasks: install-redhat.yml
+  when: ansible_os_family == 'RedHat'
+
 - include: common.yml
-#- include: users.yml
-#- include: rabbitmq.yml
+
+- name: Template out init script into /usr/bin
+  template:
+    src: init.sh.j2
+    dest: /usr/local/bin/runrabbit
+    mode: 0755

--- a/templates/init.sh.j2
+++ b/templates/init.sh.j2
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+( sleep 5 ; \
+
+rabbitmqctl start_app \
+
+sleep 5; \
+
+# Create users
+# rabbitmqctl add_user <username> <password>
+rabbitmqctl add_user {{ rabbitmq_admin_user }} {{ rabbitmq_admin_password }} ; \
+
+rabbitmqctl add_user {{ rabbitmq_application_user }} {{ rabbitmq_application_password }} ; \
+
+# Set user rights
+# rabbitmqctl set_user_tags <username> <tag>
+rabbitmqctl set_user_tags {{ rabbitmq_admin_user }} administrator ; \
+
+# Create vhosts
+# rabbitmqctl add_vhost <vhostname>
+rabbitmqctl add_vhost {{ rabbitmq_application_vhost }} ; \
+
+# Set vhost permissions
+# rabbitmqctl set_permissions -p <vhostname> <username> ".*" ".*" ".*"
+rabbitmqctl set_permissions -p {{ rabbitmq_application_vhost }} {{ rabbitmq_application_user }} ".*" ".*" ".*" ; \
+) &    
+rabbitmq-server $@

--- a/templates/init.sh.j2
+++ b/templates/init.sh.j2
@@ -23,5 +23,4 @@ rabbitmqctl add_vhost {{ rabbitmq_application_vhost }} ; \
 # Set vhost permissions
 # rabbitmqctl set_permissions -p <vhostname> <username> ".*" ".*" ".*"
 rabbitmqctl set_permissions -p {{ rabbitmq_application_vhost }} {{ rabbitmq_application_user }} ".*" ".*" ".*" ; \
-) &    
-rabbitmq-server $@
+) & /usr/bin/dumb-init rabbitmq-server $@

--- a/tests/debian-container.yml
+++ b/tests/debian-container.yml
@@ -1,8 +1,9 @@
 ---
 
 version: '2'
-conductor:
-  base: debian:jessie
+settings:
+  conductor:
+    base: debian:jessie
 services:
   rabbitmq-container:
     from: debian:jessie

--- a/tests/debian-container.yml
+++ b/tests/debian-container.yml
@@ -1,0 +1,10 @@
+---
+
+version: '2'
+conductor:
+  base: debian:jessie
+services:
+  rabbitmq-container:
+    from: debian:jessie
+    roles:
+    - rabbitmq-container


### PR DESCRIPTION
Great little role @bingoarun 

I'm building Debian containers so I generalized this role to support both major OS families.

I also added an init.sh script template which can be used to implement initial user and vhost creation.