### PR TITLE
fix Travis commit references for non-PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ script:
 
   # Install the role into the project
   
-  - echo "Installing and testing git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-TRAVIS_COMMIT}"
-  - ansible-container install git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-TRAVIS_COMMIT}
+  - echo "Installing and testing git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}"
+  - ansible-container install git+https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG},${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}
 
   # Build the service image
   - ansible-container build --no-container-cache


### PR DESCRIPTION
Sorry @bingoarun I wasn't able to test the other side of the PR vs. non-PR Travis commit environment variables since I don't control the main repo

This should fix the issue: I was missing `$` in front of the default env vars