### PR TITLE
Updating  Signing key URL for ssl certificate

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Add the RabbitMQ public GPG key to the apt repo
-  apt_key: url=http://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+  apt_key: url=https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
            state=present
 
 - name: Add RabbitMQ to the sources list
   apt_repository: 
-    repo: 'deb http://www.rabbitmq.com/debian/ testing main'
+    repo: "deb https://dl.bintray.com/rabbitmq/debian {{ distribution }} main"
     update_cache: yes
     state: present
 


### PR DESCRIPTION
Hey I am updating siging key URL for the RabbitMQ SSL. I am getting following error while I am using your bingoarun.rabbitmq-container. 
due to outdated URL. 

TASK [bingoarun.rabbitmq-container : Add the RabbitMQ public GPG key to the apt repo] ***
Post stage
fatal: [rabbit]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for www.rabbitmq.com:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)."}
	to retry, use: --limit @/src/tmppJ39wz.retry

Let me know if you think this is valid reason. 

Thank You 
Hiren Patel